### PR TITLE
Two small fixes

### DIFF
--- a/modalbox.js
+++ b/modalbox.js
@@ -447,11 +447,9 @@ Modalbox.Methods = {
 	},
 
 	_findFocusableElements: function() { // Collect form elements or links from MB content
-		if (this.options.autoFocusing === true) {
-			// TODO maybe add :enabled to select and textarea elements
-			this.MBcontent.select('input:not([type=hidden]):enabled, select, textarea, button, a[href]').invoke('addClassName', 'MB_focusable');
-			this.focusableElements = this.MBcontent.select('.MB_focusable');
-		}
+		// TODO maybe add :enabled to select and textarea elements
+		this.MBcontent.select('input:not([type=hidden]):enabled, select, textarea, button, a[href]').invoke('addClassName', 'MB_focusable');
+		this.focusableElements = this.MBcontent.select('.MB_focusable');
 	},
 	
 	_kbdHandler: function(event) {


### PR DESCRIPTION
Hi,

Take a look at the first issue here:
http://code.google.com/p/modalbox/issues/detail?id=362

The fix for this is pretty straightforward, _findFocusableElements() doesn't return anything, so instead of setting this.focusableElements, it gets unset. This fix makes sure it doesn't.

The second fix/commit makes sure this.focusableElements also gets set when autofocus is disabled. It's needed for the TAB key to work.

Regards,
Jaap Haagmans
